### PR TITLE
fix: prevent scheduler crash when removing the current task mid-step

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 AlCalzone
+Copyright (c) 2025-2026 AlCalzone
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -481,6 +481,11 @@ const scheduler = new TaskScheduler(() => new Error("We are all doomed!"));
 ```
 
 ## Changelog
+
+### **WORK IN PROGRESS**
+
+- Fixed a crash of the task scheduler that could occur when removing the currently executed task while it is performing an asynchronous operation
+
 ### 1.2.1 (2025-06-24)
 
 - Fixed some type issues for composite task definitions

--- a/src/Task.test.ts
+++ b/src/Task.test.ts
@@ -1658,3 +1658,108 @@ test("The type-safe wrapper works correctly", async (t) => {
 
 	await scheduler.stop();
 });
+
+test("The current task can remove itself synchronously mid-step", async (t) => {
+	const scheduler = new TaskScheduler();
+	const order: string[] = [];
+	scheduler.start();
+
+	let removeResult: Promise<boolean> | undefined;
+
+	const task1 = scheduler.queueTask({
+		name: "task1",
+		priority: TaskPriority.Normal,
+		task: async function* () {
+			order.push("1a");
+			await wait(1);
+			// Simulates an event handler that removes the current task
+			// while its step is still in flight
+			removeResult = scheduler.removeTasks((t) => t.name === "task1");
+			order.push("1b");
+		},
+		cleanup: async () => {
+			order.push("1c");
+			await wait(1);
+		},
+	});
+
+	await t.expect(() => task1).rejects.toThrowError("Task was removed");
+	t.expect(await removeResult!).toBe(true);
+
+	// The cleanup runs during the removeTasks call, before the generator resumes
+	t.expect(order).toStrictEqual(["1a", "1c", "1b"]);
+
+	// The scheduler must still be able to execute new tasks
+	const task2 = scheduler.queueTask({
+		priority: TaskPriority.Normal,
+		task: async function* () {
+			return 2;
+		},
+	});
+	t.expect(await task2).toBe(2);
+
+	await scheduler.stop();
+});
+
+test("The current task can be removed while it is waiting for a promise", async (t) => {
+	const scheduler = new TaskScheduler();
+	const order: string[] = [];
+	scheduler.start();
+
+	const t1WasStarted = createDeferredPromise<void>();
+	const t1CleanupStarted = createDeferredPromise<void>();
+	const t1CleanupGate = createDeferredPromise<void>();
+	const yieldedPromise = createDeferredPromise<void>();
+
+	const task1 = scheduler.queueTask({
+		name: "task1",
+		priority: TaskPriority.Normal,
+		task: async function* () {
+			order.push("1a");
+			t1WasStarted.resolve();
+			yield () => yieldedPromise;
+			order.push("1b");
+		},
+		cleanup: async () => {
+			order.push("1c");
+			t1CleanupStarted.resolve();
+			await t1CleanupGate;
+		},
+	});
+
+	await t1WasStarted;
+
+	// Remove the waiting task. Its cleanup is gated, so the removal
+	// is still in progress while the scheduler continues running.
+	const removeResult = scheduler.removeTasks((t) => t.name === "task1");
+	await t1CleanupStarted;
+
+	// Queue another task while the removal is in progress
+	const t2WasStarted = createDeferredPromise<void>();
+	const t2Gate = createDeferredPromise<void>();
+	const task2 = scheduler.queueTask({
+		name: "task2",
+		priority: TaskPriority.Normal,
+		task: async function* () {
+			order.push("2a");
+			t2WasStarted.resolve();
+			await t2Gate;
+			return "ok";
+		},
+	});
+
+	await t2WasStarted;
+
+	// Finish the removal while task 2's step is in flight
+	t1CleanupGate.resolve();
+	t.expect(await removeResult).toBe(true);
+	await t.expect(() => task1).rejects.toThrowError("Task was removed");
+
+	// Task 2 must not be affected by the removal of task 1
+	t2Gate.resolve();
+	t.expect(await task2).toBe("ok");
+
+	t.expect(order).toStrictEqual(["1a", "1c", "2a"]);
+
+	await scheduler.stop();
+});

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -151,6 +151,10 @@ export type TaskStepResult<
 			newState: TaskState.Active;
 	  }
 	| {
+			// The task was reset while the step was in flight. The result is stale and must be dropped.
+			newState: TaskState.None;
+	  }
+	| {
 			newState: TaskState.AwaitingPromise;
 			promise: Promise<unknown>;
 	  }
@@ -247,71 +251,62 @@ export class TaskScheduler<
 		predicate: (task: Task<unknown, TaskTag>) => boolean,
 		reason?: TError,
 	): Promise<boolean> {
-		// Collect tasks that should be removed, but in reverse order,
-		// so that we handle the current task last.
+		// Collect tasks that should be removed, so that we handle the current task last
 		const tasksToRemove: Task<unknown, TaskTag>[] = [];
-		let removeCurrentTask = false;
+		let currentTaskToRemove: Task<unknown, TaskTag> | undefined;
 		for (const task of this._tasks) {
 			if (predicate(task)) {
 				if (task === this._currentTask) {
-					removeCurrentTask = true;
+					currentTaskToRemove = task;
 				} else {
 					tasksToRemove.push(task);
 				}
 			}
 		}
+		if (currentTaskToRemove) {
+			tasksToRemove.push(currentTaskToRemove);
+		}
 
 		reason ??= this.defaultErrorFactory();
 
 		for (const task of tasksToRemove) {
-			if (this.verbose) {
-				console.log(`Removing task: ${getTaskName(task)}`);
+			// Skip tasks the run loop finalized during a previous iteration's await
+			if (this._currentTask !== task && !this._tasks.contains(task)) {
+				continue;
 			}
-			this._tasks.remove(task);
-			if (
-				task.state === TaskState.Active ||
-				task.state === TaskState.AwaitingPromise ||
-				task.state === TaskState.AwaitingTask
-			) {
-				// The task is running, clean it up
-				await task.reset().catch(noop);
-			}
-			task.reject(reason);
-			// Re-add the parent task to the list if there is one
-			if (task.parent) {
-				if (this.verbose) {
-					console.log(
-						`Restoring parent task: ${getTaskName(task.parent)}`,
-					);
-				}
-				this._tasks.add(task.parent);
-			}
-		}
-
-		if (removeCurrentTask && this._currentTask) {
-			if (this.verbose) {
-				console.log(`Removing task: ${getTaskName(this._currentTask)}`);
-			}
-			this._tasks.remove(this._currentTask);
-			await this._currentTask.reset().catch(noop);
-			this._currentTask.reject(reason);
-			// Re-add the parent task to the list if there is one
-			if (this._currentTask.parent) {
-				if (this.verbose) {
-					console.log(
-						`Restoring parent task: ${getTaskName(
-							this._currentTask.parent,
-						)}`,
-					);
-				}
-				this._tasks.add(this._currentTask.parent);
-			}
-			this._currentTask = undefined;
+			await this.dropTask(task, reason);
 		}
 
 		if (this._continueSignal) this._continueSignal.resolve();
 
-		return tasksToRemove.length > 0 || removeCurrentTask;
+		return tasksToRemove.length > 0;
+	}
+
+	/** Removes a single task from the queue, resets it and rejects its promise */
+	private async dropTask(
+		task: Task<unknown, TaskTag>,
+		reason: TError,
+	): Promise<void> {
+		if (this.verbose) {
+			console.log(`Removing task: ${getTaskName(task)}`);
+		}
+		this._tasks.remove(task);
+		// Claim the task before awaiting anything, so the run loop drops the
+		// result of an in-flight step instead of finalizing the task a second time
+		if (this._currentTask === task) {
+			this._currentTask = undefined;
+		}
+		await task.reset().catch(noop);
+		task.reject(reason);
+		// Re-add the parent task to the list if there is one
+		if (task.parent) {
+			if (this.verbose) {
+				console.log(
+					`Restoring parent task: ${getTaskName(task.parent)}`,
+				);
+			}
+			this._tasks.add(task.parent);
+		}
 	}
 
 	public findTask<T = unknown>(
@@ -364,9 +359,23 @@ export class TaskScheduler<
 				generator ??= builder.task();
 				state = TaskState.Active;
 
-				const { value, done } = waitError
-					? await generator.throw(waitError)
-					: await generator.next(prevResult);
+				// Capture the generator so a concurrent reset() can be detected after the await
+				const gen = generator;
+				let genResult: Awaited<ReturnType<typeof gen.next>>;
+				try {
+					genResult = waitError
+						? await gen.throw(waitError)
+						: await gen.next(prevResult);
+				} catch (e) {
+					// Drop errors from a step whose task was reset in the meantime
+					if (generator !== gen) return { newState: TaskState.None };
+					throw e;
+				}
+				// Drop the step result if the task was reset while the generator was running,
+				// so the task state is not corrupted after the reset
+				if (generator !== gen) return { newState: TaskState.None };
+
+				const { value, done } = genResult;
 				prevResult = undefined;
 				waitError = undefined;
 				if (done) {
@@ -435,6 +444,8 @@ export class TaskScheduler<
 				state = TaskState.None;
 				waitForPromise = undefined;
 				generator = undefined;
+				prevResult = undefined;
+				waitError = undefined;
 
 				await builder.cleanup?.();
 			},
@@ -483,36 +494,42 @@ export class TaskScheduler<
 						TaskInterruptBehavior.Restart
 					) {
 						// The current task needs to be restarted after being interrupted, so reset it
-						await this._currentTask.reset();
+						const interrupted = this._currentTask;
+						await interrupted.reset();
+						// Re-evaluate the queue if it changed during the reset
+						if (
+							this._currentTask !== interrupted ||
+							this._tasks.peekStart() !== firstTask
+						) {
+							continue;
+						}
 					}
 					// switch to the new task
 					this._currentTask = firstTask;
 				}
 
+				// Capture the current task, so concurrent removals can be detected after each await
+				const task = this._currentTask;
+
 				if (this.verbose) {
-					console.log(
-						`Stepping through task: ${getTaskName(
-							this._currentTask,
-						)}`,
-					);
+					console.log(`Stepping through task: ${getTaskName(task)}`);
 				}
 
-				const cleanupCurrentTask = async () => {
-					if (this._currentTask) {
-						this._tasks.remove(this._currentTask);
-						await this._currentTask.reset();
-						// Re-add the parent task to the list if there is one
-						if (this._currentTask.parent) {
-							if (this.verbose) {
-								console.log(
-									`Restoring parent task: ${getTaskName(
-										this._currentTask.parent,
-									)}`,
-								);
-							}
-							this._tasks.add(this._currentTask.parent);
+				const finalizeCurrentTask = async () => {
+					this._tasks.remove(task);
+					// Claim the task before awaiting, so a concurrent removeTasks() skips it
+					this._currentTask = undefined;
+					await task.reset();
+					// Re-add the parent task to the list if there is one
+					if (task.parent) {
+						if (this.verbose) {
+							console.log(
+								`Restoring parent task: ${getTaskName(
+									task.parent,
+								)}`,
+							);
 						}
-						this._currentTask = undefined;
+						this._tasks.add(task.parent);
 					}
 				};
 
@@ -520,25 +537,31 @@ export class TaskScheduler<
 				waitFor = undefined;
 				let stepResult: TaskStepResult<unknown, TaskTag>;
 				try {
-					stepResult = await this._currentTask.step();
+					stepResult = await task.step();
 				} catch (e) {
+					// Drop the error if the task was removed during the step. It was already rejected.
+					if (this._currentTask !== task) continue;
+
 					if (this.verbose) {
 						console.error(`- Task threw an error:`, e);
 					}
 					// The task threw an error, expose the result and clean up.
-					this._currentTask.reject(e as Error);
-					await cleanupCurrentTask();
+					task.reject(e as Error);
+					await finalizeCurrentTask();
 					// Then continue with the next iteration
 					continue;
 				}
+
+				// Drop the step result if the task was removed during the step. It was already rejected.
+				if (this._currentTask !== task) continue;
 
 				if (stepResult.newState === TaskState.Done) {
 					if (this.verbose) {
 						console.log(`- Task finished`);
 					}
 					// The task is done, clean up
-					this._currentTask.resolve(stepResult.result);
-					await cleanupCurrentTask();
+					task.resolve(stepResult.result);
+					await finalizeCurrentTask();
 					// Then continue with the next iteration
 					continue;
 				} else if (stepResult.newState === TaskState.AwaitingPromise) {
@@ -548,15 +571,12 @@ export class TaskScheduler<
 					}
 
 					// If the task may be interrupted, check if there are other same-priority tasks that should be executed instead
-					if (
-						this._currentTask.interrupt !==
-						TaskInterruptBehavior.Forbidden
-					) {
+					if (task.interrupt !== TaskInterruptBehavior.Forbidden) {
 						// Re-queue the task, so the queue gets reordered
-						this._tasks.remove(this._currentTask);
-						this._tasks.add(this._currentTask);
+						this._tasks.remove(task);
+						this._tasks.add(task);
 
-						if (this._tasks.peekStart() !== this._currentTask) {
+						if (this._tasks.peekStart() !== task) {
 							if (this.verbose) {
 								console.log(`-- Continuing with another task`);
 							}
@@ -573,11 +593,12 @@ export class TaskScheduler<
 						console.log(`- Task spawned a sub-task`);
 					}
 					this._tasks.add(stepResult.task);
-					this._tasks.remove(this._currentTask);
+					this._tasks.remove(task);
 					// Continue with the next iteration
 					continue;
 				} else {
-					// The current task is not done, continue with the next iteration
+					// The current task is not done, or the step result is stale after a removal.
+					// Continue with the next iteration.
 					continue;
 				}
 			}


### PR DESCRIPTION
### The problem

`TaskScheduler.removeTasks()` and the `run()` loop race when the current task is removed while its `step()` is in flight, permanently crashing the scheduler with:

```
Task runner crashed TypeError: Cannot read properties of undefined (reading 'parent')
    at cleanupCurrentTask (src/Task.ts:505)
```

Trigger from zwave-js: a task's generator synchronously emits an event mid-step (e.g. a node being marked asleep during the interview task), and the event handler calls `scheduler.removeTasks()` for the currently-stepping task. Three separate races compound:

- `cleanupCurrentTask` read `this._currentTask.parent` after `await this._currentTask.reset()`, but a concurrent `removeTasks()` sets `this._currentTask = undefined` during that await.
- Symmetrically, `removeTasks()` dereferenced `this._currentTask` after its own `await reset()`, by which time the run loop may have cleared or replaced it — this could even reject an unrelated task that had become current in the meantime.
- An in-flight `generator.next()` resolving after `reset()` set the state back to `Done`, causing `cleanup()` to run a second time.

### The fix

- The run loop captures the current task in a local and re-validates `this._currentTask` after every await, dropping stale step results of tasks that were removed mid-step.
- Task finalization (run loop) and removal (`removeTasks()`) now claim the task synchronously — clearing `this._currentTask` before awaiting `reset()` — so the other side skips it and the parent task is restored exactly once.
- `step()` detects a concurrent `reset()` (new `TaskState.None` step result) and drops the stale generator result instead of corrupting the task state.
- `reset()` also clears `prevResult`/`waitError` so a restarted task cannot receive a stale error.

### Regression tests

- A task whose generator removes itself synchronously between awaits mid-step
- A removal while the task is `AwaitingPromise` with a slow async cleanup, with another task starting mid-removal

Both reproduce the reported crash on `main` at v1.2.1.

Also includes the changelog entry and the copyright year bump required by the release check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)