### PR TITLE
ci: publish to npm using trusted publishing

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -2,7 +2,7 @@
 
 name: Test and Release
 
-# Run this job on pushes to master and pull requests
+# Run this job on pushes to main and pull requests
 # as well as tags with a semantic version
 on:
     push:
@@ -15,50 +15,51 @@ on:
           - "v[0-9]+.[0-9]+.[0-9]+-**"
     pull_request: {}
 
+permissions:
+  id-token: write # Required for publishing with OICD
+  contents: write # Required for creating releases
+
 jobs:
   # Runs unit tests on all supported node versions and OSes
   unit-tests:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [20.x, 22.x, 24.x]
         os: [ubuntu-latest]
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Enable Corepack
       shell: bash
       run: corepack enable
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
 
     - name: Install dependencies
-      run: yarn install --frozen-lockfile
+      run: yarn install --immutable
 
     - name: Compile
       run: yarn build
 
-    - name: Run component tests
+    - name: Unit tests
       run: yarn test
-      env:
-        CI: true
 
   # ===================
 
-  # Deploys the final package to NPM and Github Actions
+  # Deploys the final package to NPM
   deploy:
-    # Trigger this step only when a commit on master is tagged with a version number
+    # Trigger this step only when a commit on main is tagged with a version number
     if: |
       github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags/v')
 
-    needs: [unit-tests]
+    needs: unit-tests
 
     runs-on: ubuntu-latest
     strategy:
@@ -67,14 +68,14 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Enable Corepack
       shell: bash
       run: corepack enable
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
@@ -96,18 +97,15 @@ jobs:
         fi
 
     - name: Install dependencies
-      run: yarn install --frozen-lockfile
+      run: yarn install --immutable
 
     - name: Create a clean build
       run: yarn run build
 
-    - name: Publish packages to npm
+    - name: Publish package to npm
       env:
         TAG: ${{ steps.extract_release.outputs.TAG }}
-      run: |
-        yarn config set npmAuthToken "${{ secrets.NPM_TOKEN }}"
-        yarn npm whoami
-        yarn workspaces foreach --all -vti --no-private npm publish --tolerate-republish $TAG
+      run: yarn npm publish $TAG
 
     - name: Create Github Release
       uses: softprops/action-gh-release@v2

--- a/package.json
+++ b/package.json
@@ -37,5 +37,5 @@
   "dependencies": {
     "alcalzone-shared": "^5.0.0"
   },
-  "packageManager": "yarn@4.6.0"
+  "packageManager": "yarn@4.10.3"
 }


### PR DESCRIPTION
The v1.2.2 release attempt failed in the deploy job with `Invalid authentication (as an unknown user)` — the `NPM_TOKEN` secret is no longer valid. This switches the workflow to OIDC-based trusted publishing, using [zwave-js/fmt's workflow](https://github.com/zwave-js/fmt/blob/main/.github/workflows/test-and-release.yml) as the template.

Changes compared to the current workflow:

- `permissions: id-token: write` + plain `yarn npm publish` instead of `yarn config set npmAuthToken` / `yarn npm whoami` / `workspaces foreach`
- `actions/checkout@v5` and `actions/setup-node@v5`
- `yarn install --immutable` instead of the yarn-1-style `--frozen-lockfile`
- Test matrix on Node 20.x, 22.x, 24.x (the build targets node20)
- `packageManager` bumped to `yarn@4.10.3`, since yarn only supports OIDC publishing from 4.10 on. Install, build and tests pass locally with it; yarn.lock is unchanged.

One deviation from the fmt template: the publish step there references `$TAG` without mapping it from the step output, so prereleases would never get `--tag next`. This version adds the `env: TAG:` mapping (as the old workflow had).

Before the next release attempt, trusted publishing must be configured for `@zwave-js/waddle` on npmjs.com: package Settings → Trusted Publisher → GitHub Actions, with repository `zwave-js/waddle` and workflow `test-and-release.yml`. The `NPM_TOKEN` secret can be deleted afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)